### PR TITLE
Fix: tolerate 'mark' field returned as an array (breaks downloads for 'foreign agent' artists)

### DIFF
--- a/src/zvuk/client.rs
+++ b/src/zvuk/client.rs
@@ -1294,7 +1294,7 @@ mod tests {
                             "artistNames": [
                                 "Some artist"
                             ],
-                            "mark": null,
+                            "mark": ["foreign_agent"],
                             "zchan": "huh",
                             "lyrics": true,
                             "collectionItemData": {
@@ -1370,7 +1370,7 @@ mod tests {
                                 },
                                 "availability": 2,
                                 "artistTemplate": "{0}",
-                                "mark": null
+                                "mark": ["foreign_agent"]
                             },
                             "hasFlac": true
                         }

--- a/src/zvuk/dto.rs
+++ b/src/zvuk/dto.rs
@@ -195,7 +195,7 @@ pub(super) struct ZvukGQLTrack {
     explicit: bool,
     #[serde(alias = "artistNames")]
     pub(super) artist_names: Vec<String>,
-    mark: Option<String>,
+    mark: Option<serde_json::Value>,
     zchan: String,
     pub(super) lyrics: Option<bool>,
     #[serde(alias = "collectionItemData")]
@@ -249,7 +249,7 @@ pub(super) struct ZvukGQLRelease {
     availability: Option<i64>,
     #[serde(alias = "artistTemplate")]
     artist_template: Option<String>,
-    mark: Option<String>,
+    mark: Option<serde_json::Value>,
 }
 
 #[expect(unused)]
@@ -281,7 +281,7 @@ pub(super) struct ZvukGQLPlaylistTrack {
     #[serde(alias = "artistTemplate")]
     artist_template: String,
     child_param: Option<String>,
-    mark: Option<String>,
+    mark: Option<serde_json::Value>,
     pub(super) artists: Vec<ZvukGQLArtist>,
     pub(super) release: ZvukGQLRelease,
     zchan: String,


### PR DESCRIPTION
## Problem

The zvuk.com API started returning the `mark` field as an **array** for tracks and releases of artists flagged as "foreign agent" (иностранный агент) — e.g. Oxxxymiron:

```json
"mark": ["foreign_agent"]
```

The DTO declared `mark: Option<String>`, so `serde` fails with:

```
Error: Failed to get tracks metadata
Caused by:
    invalid type: sequence, expected a string
```

As a result **any track or release by such an artist cannot be downloaded** (`getTracks`/`getReleases` metadata parsing aborts).

## Fix

Change the type to `Option<serde_json::Value>` in the three affected structs (`ZvukGQLTrack`, `ZvukGQLRelease`, `ZvukGQLPlaylistTrack`). `Value` accepts any JSON shape (null / string / array / object), so the API can return whatever it wants here.

The field is never read by the application — these structs are annotated `#[expect(unused)]` and `mark` is not exposed via `pub(super)` — so loosening the type has no behavioural side effects.

## Tests

Updated the `getFullTrack` mock to return `"mark": ["foreign_agent"]` for both the track and its nested release, covering the array case through the real deserialization path. `cargo test` passes (21/21), `cargo clippy --all-targets` is clean.

## How to reproduce (before this patch)

```
zvuk-dl <any Oxxxymiron track/release URL>
=> Error: Failed to get tracks metadata
   Caused by: invalid type: sequence, expected a string
```