### PR TITLE
Fix: respect Windows LongPathsEnabled to avoid '~' folder names (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - 🐛 parsing `mark` fields in Zvuk DTOs
+- 🐛 folder name truncated to a bare `~` on Windows for long paths ([#12](https://github.com/skarrok/zvuk-dl-rs/issues/12))
+
+  Detect the `LongPathsEnabled` registry setting and target the larger
+  long-path limit when it's enabled, instead of the conservative `MAX_PATH`.
 
 ## [0.5.1] - 2026-05-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -2666,6 +2675,16 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2892,4 +2911,5 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "winreg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ supports-color = "3.0.2"
 tracing-subscriber = { version = "0.3.23", features = ["json", "env-filter"] }
 tracing = { version = "0.1.44", features = ["log"] }
 
+[target.'cfg(windows)'.dependencies]
+# Used to detect whether long paths are enabled in the registry.
+winreg = "0.55"
+
 [dev-dependencies]
 httpmock = "0.8.3"
 tempfile = "3.27.0"

--- a/src/path.rs
+++ b/src/path.rs
@@ -64,7 +64,7 @@ pub fn effective_max_total_path_len() -> usize {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn effective_max_total_path_len() -> usize {
+pub const fn effective_max_total_path_len() -> usize {
     MAX_TOTAL_PATH_LEN
 }
 
@@ -543,7 +543,8 @@ mod tests {
             .into_owned();
         assert_eq!(conservative_dir, "~");
 
-        let long = normalize_path(&path, true, "seed", LONG_MAX_TOTAL_PATH_LEN);
+        let long =
+            normalize_path(&path, true, "seed", LONG_MAX_TOTAL_PATH_LEN);
         let long_dir = long
             .parent()
             .and_then(Path::file_name)

--- a/src/path.rs
+++ b/src/path.rs
@@ -23,6 +23,51 @@ const MAX_TOTAL_PATH_LEN: usize = 1024;
 )))]
 const MAX_TOTAL_PATH_LEN: usize = 1024;
 
+// Windows supports paths up to ~32767 chars when long paths are enabled
+// (registry key LongPathsEnabled). Rust's std transparently prefixes paths
+// over MAX_PATH with `\\?\`, so we can target this larger limit in that case.
+#[cfg(target_os = "windows")]
+const LONG_MAX_TOTAL_PATH_LEN: usize = 32_767;
+
+/// Returns whether long paths are enabled for the system via the
+/// `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled` registry
+/// value. Returns `false` if the value is missing or unreadable.
+#[cfg(target_os = "windows")]
+fn long_paths_enabled() -> bool {
+    use winreg::RegKey;
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+
+    RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey(r"SYSTEM\CurrentControlSet\Control\FileSystem")
+        .and_then(|key| key.get_value::<u32, _>("LongPathsEnabled"))
+        .is_ok_and(|value| value == 1)
+}
+
+/// The maximum total path length to target.
+///
+/// On Windows this is the larger long-path limit when `LongPathsEnabled` is
+/// set in the registry, otherwise the conservative `MAX_PATH`-based default.
+/// The result is detected once and cached. On other platforms it is the
+/// platform default.
+#[cfg(target_os = "windows")]
+pub fn effective_max_total_path_len() -> usize {
+    use std::sync::OnceLock;
+
+    static CACHED: OnceLock<usize> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        if long_paths_enabled() {
+            LONG_MAX_TOTAL_PATH_LEN
+        } else {
+            MAX_TOTAL_PATH_LEN
+        }
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn effective_max_total_path_len() -> usize {
+    MAX_TOTAL_PATH_LEN
+}
+
 fn component_len(value: &str) -> usize {
     if cfg!(target_os = "windows") {
         value.encode_utf16().count()
@@ -217,6 +262,7 @@ pub fn normalize_path(
     path: &Path,
     can_truncate_parent_folder: bool,
     seed: &str,
+    max_total_path_len: usize,
 ) -> PathBuf {
     let mut parent = path.parent().map(Path::to_path_buf);
     let mut directory = parent
@@ -265,9 +311,9 @@ pub fn normalize_path(
             .map_or_else(|| file_name.clone().into(), |p| p.join(file_name));
     }
 
-    if path_len(path) > MAX_TOTAL_PATH_LEN {
+    if path_len(path) > max_total_path_len {
         if can_truncate_parent_folder {
-            let available_dir_len = MAX_TOTAL_PATH_LEN
+            let available_dir_len = max_total_path_len
                 .saturating_sub(parent.as_ref().map_or(0, |p| path_len(p)))
                 .saturating_sub(2)
                 .saturating_sub(
@@ -297,8 +343,8 @@ pub fn normalize_path(
             }
         }
 
-        if path_len(&normalized_path) > MAX_TOTAL_PATH_LEN {
-            let available_filename_len = MAX_TOTAL_PATH_LEN
+        if path_len(&normalized_path) > max_total_path_len {
+            let available_filename_len = max_total_path_len
                 .saturating_sub(parent.as_ref().map_or(0, |p| path_len(p)))
                 .saturating_sub(1)
                 .clamp(1, MAX_COMPONENT_LEN);
@@ -358,7 +404,8 @@ mod tests {
     fn normalize_path_preserves_extension_with_limit() {
         let stem = "a".repeat(MAX_COMPONENT_LEN * 2);
         let path = PathBuf::from(stem).with_extension("flac");
-        let normalized = normalize_path(&path, false, "seed");
+        let normalized =
+            normalize_path(&path, false, "seed", MAX_TOTAL_PATH_LEN);
 
         dbg!(&normalized);
 
@@ -372,7 +419,8 @@ mod tests {
         let file_name = format!("{}.mp3", "n".repeat(MAX_COMPONENT_LEN + 50));
         let path = PathBuf::from(parent).join(file_name);
 
-        let normalized = normalize_path(&path, true, "track-id");
+        let normalized =
+            normalize_path(&path, true, "track-id", MAX_TOTAL_PATH_LEN);
 
         assert!(path_len(&normalized) <= MAX_TOTAL_PATH_LEN);
 
@@ -450,6 +498,7 @@ mod tests {
                     .with_extension(case.extension),
                 case.can_truncate_parent_folder,
                 "seed",
+                MAX_TOTAL_PATH_LEN,
             );
 
             assert!(path_len(&normalized) <= MAX_TOTAL_PATH_LEN);
@@ -463,7 +512,8 @@ mod tests {
         let parent = "p".repeat(MAX_TOTAL_PATH_LEN - 4);
         let path = PathBuf::from(parent).join("CON.mp3");
 
-        let normalized = normalize_path(&path, true, "track-id");
+        let normalized =
+            normalize_path(&path, true, "track-id", MAX_TOTAL_PATH_LEN);
         let file_name = normalized
             .file_name()
             .expect("normalized path must contain filename")
@@ -471,5 +521,35 @@ mod tests {
             .into_owned();
 
         assert_eq!(file_name, "_CON.mp3");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn normalize_path_preserves_directory_with_long_path_limit() {
+        // A deep base directory leaves almost no budget for the album folder
+        // under the conservative MAX_PATH limit, so it collapses to a bare "~".
+        // With long paths enabled the folder name is kept intact.
+        let base = "b".repeat(MAX_TOTAL_PATH_LEN - 10);
+        let directory = "Various Artists Compilation";
+        let path = PathBuf::from(&base).join(directory).join("01 - Track.mp3");
+
+        let conservative =
+            normalize_path(&path, true, "seed", MAX_TOTAL_PATH_LEN);
+        let conservative_dir = conservative
+            .parent()
+            .and_then(Path::file_name)
+            .expect("path must contain a directory")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(conservative_dir, "~");
+
+        let long = normalize_path(&path, true, "seed", LONG_MAX_TOTAL_PATH_LEN);
+        let long_dir = long
+            .parent()
+            .and_then(Path::file_name)
+            .expect("path must contain a directory")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(long_dir, directory);
     }
 }

--- a/src/zvuk/client.rs
+++ b/src/zvuk/client.rs
@@ -1214,6 +1214,7 @@ fn track_target_paths(
         &filepath,
         can_truncate_parent_folder,
         &track_info.track_id,
+        crate::path::effective_max_total_path_len(),
     );
 
     let directory_path = filepath


### PR DESCRIPTION
Closes #12.

## Problem

On Windows the total path limit is a fixed `240` (conservative `MAX_PATH`). For releases with long folder names — e.g. compilations crediting many artists — the path exceeds the limit, the budget left for the album folder clamps to `1`, and the folder collapses to a single **`~`**:

```
...\downloads\~\09 - Track.flac
              ^ whole "Artist1, Artist2, ... - Album (Year)" folder lost
```

## Approach (per your guidance on #12 — "option 2")

Detect the `LongPathsEnabled` registry value
(`HKLM\SYSTEM\CurrentControlSet\Control\FileSystem`) once at runtime. When it's enabled, target the larger long-path limit (`32767`); otherwise keep the conservative `240`. Rust's std transparently prefixes over-`MAX_PATH` paths with `\?\`, so this works end to end. Users **without** long paths are unaffected.

## Notes for review

- **`normalize_path` now takes the limit as a parameter** (dependency injection). This keeps the truncation tests deterministic regardless of the CI host's registry state — otherwise the existing `tmp\~\…` expectation would flip on runners that have long paths enabled (GitHub's Windows runners do). Production passes `effective_max_total_path_len()`.
- **New dependency:** `winreg` (Windows-only, `[target.'cfg(windows)'.dependencies]`). Chosen because the crate forbids `unsafe_code`, so a raw `ntdll` FFI wasn't an option. Happy to swap the approach if you'd prefer.
- The detection result is cached (`OnceLock`).
- Added a test asserting the album folder is preserved under the long-path limit and still collapses to `~` under the conservative one.

## Verification

`cargo test` (22/22) and `cargo clippy --all-targets --all-features` are green locally on Windows.